### PR TITLE
encode_accessors.h: include "config.h" to allow header to stand alone

### DIFF
--- a/src/encode_accessors.h
+++ b/src/encode_accessors.h
@@ -50,6 +50,8 @@
 #ifndef ENCODE_ACCESSORS_H
 #define ENCODE_ACCESSORS_H 1
 
+#include "config.h"
+
 #if HAVE_STDINT_H
 #  include <stdint.h>
 #endif


### PR DESCRIPTION
Some compilers do header precompilation and this requires that each
header can stand alone.  Including config.h sets HAVE_STDINT_H.