### PR TITLE
Remove HAVE_STDINT_H (fixes #4).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,6 @@ set(CMAKE_BUILD_TYPE Release)
 enable_testing()
 
 check_include_files(malloc.h HAVE_MALLOC_H)
-check_include_files(stdint.h HAVE_STDINT_H)
 test_big_endian(WORDS_BIGENDIAN)
 check_clzll(HAVE_DECL___BUILTIN_CLZLL)
 if(NOT HAVE_DECL___BUILTIN_CLZLL)

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -1,5 +1,4 @@
 #cmakedefine HAVE_MALLOC_H 1
-#cmakedefine HAVE_STDINT_H 1
 #cmakedefine WORDS_BIGENDIAN 1
 #cmakedefine HAVE_DECL___BUILTIN_CLZLL 1
 #cmakedefine HAVE_BSR64 1

--- a/src/decode.h
+++ b/src/decode.h
@@ -53,9 +53,7 @@
 
 #include <config.h>
 
-#if HAVE_STDINT_H
-#  include <stdint.h>
-#endif
+#include <stdint.h>
 
 #define M_CONTINUE 1
 #define M_EXIT 0

--- a/src/encode.h
+++ b/src/encode.h
@@ -53,9 +53,7 @@
 
 #include <config.h>
 
-#if HAVE_STDINT_H
-#  include <stdint.h>
-#endif
+#include <stdint.h>
 
 #define M_CONTINUE 1
 #define M_EXIT 0

--- a/src/encode_accessors.c
+++ b/src/encode_accessors.c
@@ -49,10 +49,7 @@
 
 #include <config.h>
 
-#if HAVE_STDINT_H
-# include <stdint.h>
-#endif
-
+#include <stdint.h>
 #include <string.h>
 #include "libaec.h"
 #include "encode.h"

--- a/src/encode_accessors.h
+++ b/src/encode_accessors.h
@@ -52,9 +52,7 @@
 
 #include "config.h"
 
-#if HAVE_STDINT_H
-#  include <stdint.h>
-#endif
+#include <stdint.h>
 
 uint32_t aec_get_8(struct aec_stream *strm);
 uint32_t aec_get_lsb_16(struct aec_stream *strm);


### PR DESCRIPTION
C99 is now required.  Therefore HAVE_STDINT_H is no longer necessary.