### PR TITLE
MingGW compilers have visibility

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,7 +52,7 @@ add_executable(graec graec.c)
 target_link_libraries(graec aec)
 
 include(GNUInstallDirs)
-if(UNIX)
+if(UNIX OR MINGW)
   # Handle visibility of symbols. Compatible with gnulib's gl_VISIBILITY
   include(CheckCCompilerFlag)
   check_c_compiler_flag(-fvisibility=hidden COMPILER_HAS_HIDDEN_VISIBILITY)


### PR DESCRIPTION
Applies to both GCC and Clang on Windows