### PR TITLE
Optionally, build only shared or only static libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,9 +74,9 @@ set(libaec_CONFIG_VERSION_IN  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/libaec-config-ve
 set(libaec_CONFIG_VERSION_OUT ${CMAKE_CURRENT_BINARY_DIR}/cmake/libaec-config-version.cmake)
 configure_file(${libaec_CONFIG_VERSION_IN} ${libaec_CONFIG_VERSION_OUT} @ONLY)
 install(FILES ${libaec_CONFIG_OUT}
-        DESTINATION cmake)
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libaec)
 install(FILES ${libaec_CONFIG_VERSION_OUT}
-        DESTINATION cmake)
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libaec)
 
 # Cpack configuration mainly for Windows installer
 set(CPACK_PACKAGE_NAME "libaec")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.13...3.19)
 project(libaec LANGUAGES C VERSION 1.1.3)
 
+option(BUILD_SHARED_LIBS "OFF: do not build shared libraries.  ON (default): build shared libraries" ON)
+option(BUILD_STATIC_LIBS "OFF: do not build static libraries.  ON (default): build static libraries" ON)
+
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,43 +11,57 @@ target_include_directories(aec
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>"
   "$<INSTALL_INTERFACE:include>")
 
-# Create both static and shared aec library.
-add_library(aec_static STATIC "$<TARGET_OBJECTS:aec>")
-target_link_libraries(aec_static PUBLIC aec)
-set_target_properties(aec_static
+set_target_properties(aec
   PROPERTIES
-  OUTPUT_NAME $<IF:$<BOOL:${MSVC}>,aec-static,aec>)
-
-add_library(aec_shared SHARED "$<TARGET_OBJECTS:aec>")
-target_link_libraries(aec_shared PUBLIC aec)
-set_target_properties(aec_shared
-  PROPERTIES
-  VERSION 0.1.3
-  SOVERSION 0
-  OUTPUT_NAME aec
   PUBLIC_HEADER ${CMAKE_CURRENT_BINARY_DIR}/../include/libaec.h)
+
+# Optionally, create both static and shared aec library.
+if(BUILD_STATIC_LIBS)
+  add_library(aec_static STATIC "$<TARGET_OBJECTS:aec>")
+  target_link_libraries(aec_static PUBLIC aec)
+  set_target_properties(aec_static
+    PROPERTIES
+    OUTPUT_NAME $<IF:$<BOOL:${MSVC}>,aec-static,aec>)
+endif()
+
+if(BUILD_SHARED_LIBS)
+  add_library(aec_shared SHARED "$<TARGET_OBJECTS:aec>")
+  target_link_libraries(aec_shared PUBLIC aec)
+  set_target_properties(aec_shared
+    PROPERTIES
+    VERSION 0.1.3
+    SOVERSION 0
+    OUTPUT_NAME aec)
+endif()
 
 # Wrapper for compatibility with szip
 add_library(sz OBJECT sz_compat.c)
 target_link_libraries(sz PUBLIC aec)
 
+set_target_properties(sz
+  PROPERTIES
+  PUBLIC_HEADER ../include/szlib.h)
+
 set(libaec_COMPILE_DEFINITIONS "LIBAEC_BUILD;LIBAEC_SHARED")
 
-# Create both static and shared szip library.
-add_library(sz_static STATIC "$<TARGET_OBJECTS:sz>" "$<TARGET_OBJECTS:aec>")
-set_target_properties(sz_static
-  PROPERTIES
-  OUTPUT_NAME $<IF:$<BOOL:${MSVC}>,szip-static,sz>)
-target_link_libraries(sz_static PUBLIC sz)
+# Optionally, create both static and shared szip library.
+if(BUILD_STATIC_LIBS)
+  add_library(sz_static STATIC "$<TARGET_OBJECTS:sz>" "$<TARGET_OBJECTS:aec>")
+  set_target_properties(sz_static
+    PROPERTIES
+    OUTPUT_NAME $<IF:$<BOOL:${MSVC}>,szip-static,sz>)
+  target_link_libraries(sz_static PUBLIC sz)
+endif()
 
-add_library(sz_shared SHARED "$<TARGET_OBJECTS:sz>" "$<TARGET_OBJECTS:aec>")
-target_link_libraries(sz_shared PUBLIC sz)
-set_target_properties(sz_shared
-  PROPERTIES
-  VERSION 2.0.1
-  SOVERSION 2
-  OUTPUT_NAME $<IF:$<BOOL:${MSVC}>,szip,sz>
-  PUBLIC_HEADER ../include/szlib.h)
+if(BUILD_SHARED_LIBS)
+  add_library(sz_shared SHARED "$<TARGET_OBJECTS:sz>" "$<TARGET_OBJECTS:aec>")
+  target_link_libraries(sz_shared PUBLIC sz)
+  set_target_properties(sz_shared
+    PROPERTIES
+    VERSION 2.0.1
+    SOVERSION 2
+    OUTPUT_NAME $<IF:$<BOOL:${MSVC}>,szip,sz>)
+endif()
 
 # Simple executable for testing and benchmarking.
 add_executable(graec graec.c)
@@ -75,4 +89,9 @@ set_target_properties(aec sz
   PROPERTIES
   COMPILE_DEFINITIONS "${libaec_COMPILE_DEFINITIONS}")
 
-install(TARGETS aec_static aec_shared sz_static sz_shared)
+if(BUILD_STATIC_LIBS)
+  install(TARGETS aec_static sz_static)
+endif()
+if(BUILD_SHARED_LIBS)
+  install(TARGETS aec_shared sz_shared)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ endif()
 if(BUILD_SHARED_LIBS)
   add_library(aec_shared SHARED "$<TARGET_OBJECTS:aec>")
   target_link_libraries(aec_shared PUBLIC aec)
+  target_compile_definitions(aec_shared PRIVATE LIBAEC_SHARED)
   set_target_properties(aec_shared
     PROPERTIES
     VERSION 0.1.3
@@ -42,7 +43,7 @@ set_target_properties(sz
   PROPERTIES
   PUBLIC_HEADER ../include/szlib.h)
 
-set(libaec_COMPILE_DEFINITIONS "LIBAEC_BUILD;LIBAEC_SHARED")
+set(libaec_COMPILE_DEFINITIONS "LIBAEC_BUILD")
 
 # Optionally, create both static and shared szip library.
 if(BUILD_STATIC_LIBS)
@@ -56,6 +57,7 @@ endif()
 if(BUILD_SHARED_LIBS)
   add_library(sz_shared SHARED "$<TARGET_OBJECTS:sz>" "$<TARGET_OBJECTS:aec>")
   target_link_libraries(sz_shared PUBLIC sz)
+  target_compile_definitions(sz_shared PRIVATE LIBAEC_SHARED)
   set_target_properties(sz_shared
     PROPERTIES
     VERSION 2.0.1
@@ -85,9 +87,8 @@ if(UNIX)
     DEPENDS graec utime)
 endif()
 
-set_target_properties(aec sz
-  PROPERTIES
-  COMPILE_DEFINITIONS "${libaec_COMPILE_DEFINITIONS}")
+target_compile_definitions(aec PRIVATE "${libaec_COMPILE_DEFINITIONS}")
+target_compile_definitions(sz PRIVATE "${libaec_COMPILE_DEFINITIONS}")
 
 if(BUILD_STATIC_LIBS)
   install(TARGETS aec_static sz_static)


### PR DESCRIPTION
Add configuration options `BUILD_SHARED_LIBS` and `BUILD_STATIC_LIBS` that can be used to select whether the shared and/or the static libraries should be build. The names for these options are widely used for this purpose by many projects that use CMake as their build system.

Additionally, set the `PUBLIC_HEADERS` property for both the static and the shared libraries.

This change covers parts of the changes by @bansan85 in https://github.com/bansan85/libaec/commit/00203c87449e749d763026b5065365e81a9dedb4.
But it tries to use more "standardized" names for the configure options.

Additionally, do not use `dllexport` or `dllimport` attributes when building static libraries.
These attributes can only be used when building .dll files (i.e., shared libraries) on Windows.

Also, install the generated CMake Config files at the correct prefix.

There are still a couple more changes in @bansan85's fork that might be nice to integrate. I'll try to have a look at that later.
