### PR TITLE
Synchronize linkage and output names across platforms and build systems

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,9 @@ if(BUILD_SHARED_LIBS)
     VERSION 0.1.4
     SOVERSION 0
     OUTPUT_NAME aec)
+  if(MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC"))
+    set_target_properties(aec-shared PROPERTIES IMPORT_SUFFIX "_imp.lib")
+  endif()
 
   # Shared libsz
   add_library(sz-shared-objects OBJECT sz_compat.c)
@@ -61,7 +64,7 @@ if(BUILD_SHARED_LIBS)
     SOVERSION 2
     OUTPUT_NAME sz)
   if(MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC"))
-    set_target_properties(sz-shared PROPERTIES OUTPUT_NAME szip)
+    set_target_properties(sz-shared PROPERTIES IMPORT_SUFFIX "_imp.lib")
   endif()
   # Add include directory directly to sz-shared so config can get it.
   target_include_directories(sz-shared
@@ -79,9 +82,6 @@ if(BUILD_STATIC_LIBS)
   add_library(aec-static STATIC "$<TARGET_OBJECTS:aec-static-objects>")
   target_link_libraries(aec-static PUBLIC aec-static-objects)
   set_target_properties(aec-static PROPERTIES OUTPUT_NAME aec)
-  if(MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC"))
-    set_target_properties(aec-static PROPERTIES OUTPUT_NAME aec-static)
-  endif()
 
   # Static libsz
   add_library(sz-static-objects OBJECT sz_compat.c)
@@ -91,9 +91,6 @@ if(BUILD_STATIC_LIBS)
     "$<TARGET_OBJECTS:aec-static-objects>")
   target_link_libraries(sz-static PUBLIC sz-static-objects)
   set_target_properties(sz-static PROPERTIES OUTPUT_NAME sz)
-  if(MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC"))
-    set_target_properties(sz-static PROPERTIES OUTPUT_NAME szip-static)
-  endif()
   # Add include directory directly to sz-static so config can get it.
   target_include_directories(sz-static
     PUBLIC "$<INSTALL_INTERFACE:include>")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,9 +55,8 @@ if(BUILD_SHARED_LIBS)
     PUBLIC "LIBAEC_SHARED"
     PRIVATE "LIBAEC_BUILD")
   add_library(sz-shared SHARED
-    "$<TARGET_OBJECTS:sz-shared-objects>"
-    "$<TARGET_OBJECTS:aec-shared-objects>")
-  target_link_libraries(sz-shared PUBLIC sz-shared-objects)
+    "$<TARGET_OBJECTS:sz-shared-objects>")
+  target_link_libraries(sz-shared PUBLIC aec-shared)
   set_target_properties(sz-shared
     PROPERTIES
     VERSION 2.0.1
@@ -87,9 +86,8 @@ if(BUILD_STATIC_LIBS)
   add_library(sz-static-objects OBJECT sz_compat.c)
   aec_common_include(sz-static-objects "${szlib_header}")
   add_library(sz-static STATIC
-    "$<TARGET_OBJECTS:sz-static-objects>"
-    "$<TARGET_OBJECTS:aec-static-objects>")
-  target_link_libraries(sz-static PUBLIC sz-static-objects)
+    "$<TARGET_OBJECTS:sz-static-objects>")
+  target_link_libraries(sz-static PUBLIC aec-static)
   set_target_properties(sz-static PROPERTIES OUTPUT_NAME sz)
   # Add include directory directly to sz-static so config can get it.
   target_include_directories(sz-static


### PR DESCRIPTION
The end goal is to output _pkg-config_ (`.pc`) files.

The static libraries are named `aec-static` and `szip-static` when building with _MSVC_—presumably to avoid clashing with the corresponding import library names—but it is not clear to me why the _MSVC_ build also changes the name of the `sz` shared library to `szip`. This pull request homogenizes library names such that installed shared and static libraries can be linked using the same names (`aec` and `sz`, respectively) everywhere tested:

| Platform | Shared library | Import library | Static library |
|---|---|---|---|
| Linux | `lib/libsz.so` | N/A | `lib/libsz.a` |
| macOS | `lib/libsz.dylib` | N/A | `lib/libsz.a` |
| MSYS2 | `bin/libsz.dll` | `lib/libsz.dll.a` | `lib/libsz.a` |
| Windows | `bin/sz.dll` | `lib/sz_imp.lib` | `lib/sz.lib` |

And analogously for the `aec` library. See _e.g._ https://github.com/curl/curl/pull/6225 for a longer discussion on this topic.

Furthermore, `sz` is linked against `aec` when building with the _Autotools_ but not when building with _CMake_. This pull request changes `src/CMakeLists.txt` to link `sz` against `aec` instead of duplicating the objects (reduces the size of the _CMake_-built `sz` library from 52 kiB to 16 kiB on Linux).

